### PR TITLE
CI debian bullseye and buster

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -54,3 +54,33 @@ jobs:
       run: cmake --build build -j 4
     - name: install
       run: cd build && make install
+
+  build-debian-bullseye:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: debian:bullseye
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: prepare
+      run: apt-get update &&
+           apt-get install -y
+             git make gcc g++
+    - name: submodules
+      run: git config --global --add safe.directory '*' &&
+           git submodule update --init
+    - name: apt-get
+      run: apt-get update &&
+           apt-get install -y
+                    build-essential cmake libboost-all-dev
+                    qtbase5-dev-tools libquazip5-dev libqwt-qt5-dev
+                    zlib1g-dev libusb-dev libqt5websockets5-dev ninja-build
+                    libgraphviz-dev libqt5svg5-dev
+    - name: configure
+      run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
+    - name: build
+      run: cmake --build build -j 4
+    - name: install
+      run: cd build && make install

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -84,3 +84,33 @@ jobs:
       run: cmake --build build -j 4
     - name: install
       run: cd build && make install
+
+  build-debian-buster:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: debian:buster
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: prepare
+      run: apt-get update &&
+           apt-get install -y
+             git make gcc g++
+    - name: submodules
+      run: git config --global --add safe.directory '*' &&
+           git submodule update --init
+    - name: apt-get
+      run: apt-get update &&
+           apt-get install -y
+                    build-essential cmake libboost-all-dev qt5-default
+                    qtbase5-dev-tools libquazip5-dev libqwt-qt5-dev
+                    zlib1g-dev libusb-dev libqt5websockets5-dev ninja-build
+                    libgraphviz-dev libqt5svg5-dev
+    - name: configure
+      run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
+    - name: build
+      run: cmake --build build -j 4
+    - name: install
+      run: cd build && make install


### PR DESCRIPTION
Thanks for adding the CI scripts for debian bookworm.

In this PR are added CI for bullseye and buster, which however do not work.
They fail at `cmake` versions required (3.13 for buster (3.15 needed for `mvme`), and 3.18 for bullseye (3.19 needed for `mesytec-mvlc`)).

It would be nice to be able to compile and run the code on a bullseye installation.  (buster just tested since the README.md` refers to that.)  I.e., see this PR as a placeholder.